### PR TITLE
Add scroll sync between editor and preview, resizable split pane

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -488,6 +488,217 @@
     if (previewScroll) previewScroll.addEventListener("scroll", () => scheduleLayout(refs));
     window.addEventListener("resize", () => scheduleLayout(refs));
 
+    // Scroll sync between editor and preview
+    if (editorTextarea && previewScroll && previewContent) {
+      let scrollSyncSource = null;
+      let scrollSyncTimer = null;
+      let editorLineOffsets = null;
+
+      function clearSyncLock() {
+        clearTimeout(scrollSyncTimer);
+        scrollSyncTimer = setTimeout(() => { scrollSyncSource = null; }, 150);
+      }
+
+      function getSourceLineElements() {
+        return previewContent.querySelectorAll("[data-source-line]");
+      }
+
+      function buildEditorLineOffsets() {
+        const mirror = document.createElement("div");
+        const cs = getComputedStyle(editorTextarea);
+        mirror.style.position = "absolute";
+        mirror.style.visibility = "hidden";
+        mirror.style.whiteSpace = "pre-wrap";
+        mirror.style.wordWrap = "break-word";
+        mirror.style.overflowWrap = "break-word";
+        mirror.style.width = cs.width;
+        mirror.style.fontFamily = cs.fontFamily;
+        mirror.style.fontSize = cs.fontSize;
+        mirror.style.lineHeight = cs.lineHeight;
+        mirror.style.letterSpacing = cs.letterSpacing;
+        mirror.style.paddingLeft = cs.paddingLeft;
+        mirror.style.paddingRight = cs.paddingRight;
+        mirror.style.paddingTop = cs.paddingTop;
+        mirror.style.borderLeft = cs.borderLeft;
+        mirror.style.borderRight = cs.borderRight;
+        mirror.style.boxSizing = cs.boxSizing;
+        mirror.style.tabSize = cs.tabSize;
+        document.body.appendChild(mirror);
+
+        const lines = editorTextarea.value.split("\n");
+        const offsets = new Array(lines.length);
+        let html = "";
+        for (let i = 0; i < lines.length; i++) {
+          html += `<span data-ln="${i}"></span>` + escapeHtml(lines[i]) + "\n";
+        }
+        mirror.innerHTML = html;
+
+        for (let i = 0; i < lines.length; i++) {
+          const marker = mirror.querySelector(`[data-ln="${i}"]`);
+          offsets[i] = marker ? marker.offsetTop : 0;
+        }
+
+        document.body.removeChild(mirror);
+        editorLineOffsets = offsets;
+      }
+
+      function editorPixelToSourceLine(px) {
+        if (!editorLineOffsets || !editorLineOffsets.length) return 0;
+        let lo = 0, hi = editorLineOffsets.length - 1;
+        while (lo < hi) {
+          const mid = (lo + hi + 1) >> 1;
+          if (editorLineOffsets[mid] <= px) lo = mid;
+          else hi = mid - 1;
+        }
+        const nextIdx = Math.min(lo + 1, editorLineOffsets.length - 1);
+        const span = editorLineOffsets[nextIdx] - editorLineOffsets[lo];
+        const frac = span > 0 ? (px - editorLineOffsets[lo]) / span : 0;
+        return lo + frac;
+      }
+
+      function sourceLineToEditorPixel(line) {
+        if (!editorLineOffsets || !editorLineOffsets.length) return 0;
+        const idx = Math.floor(line);
+        const frac = line - idx;
+        const clamped = Math.min(idx, editorLineOffsets.length - 1);
+        const nextIdx = Math.min(clamped + 1, editorLineOffsets.length - 1);
+        const base = editorLineOffsets[clamped];
+        const span = editorLineOffsets[nextIdx] - base;
+        return base + span * frac;
+      }
+
+      let offsetRebuildTimer = null;
+      function scheduleOffsetRebuild() {
+        clearTimeout(offsetRebuildTimer);
+        offsetRebuildTimer = setTimeout(buildEditorLineOffsets, 200);
+      }
+
+      editorTextarea.addEventListener("input", scheduleOffsetRebuild);
+      new ResizeObserver(scheduleOffsetRebuild).observe(editorTextarea);
+      editorTextarea.addEventListener("scrollsync:rebuild", buildEditorLineOffsets);
+
+      editorTextarea.addEventListener("scroll", () => {
+        if (scrollSyncSource === "preview") return;
+        scrollSyncSource = "editor";
+        clearSyncLock();
+
+        if (!editorLineOffsets) return;
+        const elements = getSourceLineElements();
+        if (!elements.length) return;
+
+        if (editorTextarea.scrollTop + editorTextarea.clientHeight >= editorTextarea.scrollHeight - 2) {
+          previewScroll.scrollTop = previewScroll.scrollHeight;
+          return;
+        }
+
+        const topLine = editorPixelToSourceLine(editorTextarea.scrollTop);
+
+        let prev = null;
+        let next = null;
+        for (const el of elements) {
+          const sl = parseInt(el.dataset.sourceLine, 10);
+          if (sl <= topLine) {
+            prev = el;
+          } else {
+            next = el;
+            break;
+          }
+        }
+
+        if (!prev) {
+          previewScroll.scrollTop = 0;
+          return;
+        }
+
+        const prevLine = parseInt(prev.dataset.sourceLine, 10);
+        let targetTop = prev.offsetTop - previewContent.offsetTop;
+
+        if (next) {
+          const nextLine = parseInt(next.dataset.sourceLine, 10);
+          const nextTop = next.offsetTop - previewContent.offsetTop;
+          const frac = nextLine > prevLine ? (topLine - prevLine) / (nextLine - prevLine) : 0;
+          targetTop += (nextTop - targetTop) * frac;
+        }
+
+        previewScroll.scrollTop = Math.max(0, targetTop);
+      });
+
+      previewScroll.addEventListener("scroll", () => {
+        if (scrollSyncSource === "editor") return;
+        scrollSyncSource = "preview";
+        clearSyncLock();
+
+        if (!editorLineOffsets) return;
+        const elements = getSourceLineElements();
+        if (!elements.length) return;
+
+        if (previewScroll.scrollTop + previewScroll.clientHeight >= previewScroll.scrollHeight - 2) {
+          editorTextarea.scrollTop = editorTextarea.scrollHeight;
+          return;
+        }
+
+        const scrollY = previewScroll.scrollTop;
+        let prev = null;
+        let next = null;
+        for (const el of elements) {
+          const elTop = el.offsetTop - previewContent.offsetTop;
+          if (elTop <= scrollY) {
+            prev = el;
+          } else {
+            next = el;
+            break;
+          }
+        }
+
+        if (!prev) {
+          editorTextarea.scrollTop = 0;
+          return;
+        }
+
+        const prevLine = parseInt(prev.dataset.sourceLine, 10);
+        let targetLine = prevLine;
+
+        if (next) {
+          const prevTop = prev.offsetTop - previewContent.offsetTop;
+          const nextTop = next.offsetTop - previewContent.offsetTop;
+          const nextLine = parseInt(next.dataset.sourceLine, 10);
+          const span = nextTop - prevTop;
+          const frac = span > 0 ? (scrollY - prevTop) / span : 0;
+          targetLine += (nextLine - prevLine) * frac;
+        }
+
+        editorTextarea.scrollTop = sourceLineToEditorPixel(targetLine);
+      });
+    }
+
+    // Resizable split pane
+    const resizeHandle = document.getElementById("resizeHandle");
+    if (resizeHandle) {
+      let dragging = false;
+      const workspace = document.querySelector(".workspace");
+      resizeHandle.addEventListener("mousedown", (e) => {
+        e.preventDefault();
+        dragging = true;
+        resizeHandle.classList.add("dragging");
+        document.body.style.cursor = "col-resize";
+        document.body.style.userSelect = "none";
+      });
+      document.addEventListener("mousemove", (e) => {
+        if (!dragging || !workspace) return;
+        const rect = workspace.getBoundingClientRect();
+        const pct = ((e.clientX - rect.left) / rect.width) * 100;
+        const clamped = Math.max(20, Math.min(80, pct));
+        workspace.style.gridTemplateColumns = `${clamped}% 4px 1fr`;
+      });
+      document.addEventListener("mouseup", () => {
+        if (!dragging) return;
+        dragging = false;
+        resizeHandle.classList.remove("dragging");
+        document.body.style.cursor = "";
+        document.body.style.userSelect = "";
+      });
+    }
+
     document.addEventListener("selectionchange", () => {
       if (state.page === "list" || state.modalOpen) {
         return;
@@ -743,6 +954,7 @@
       }
       if (refsArg.editorTextarea) {
         refsArg.editorTextarea.value = payload.note.markdown || "";
+        refsArg.editorTextarea.dispatchEvent(new Event("scrollsync:rebuild"));
       }
       setPreviewHtml(refsArg, payload.note.renderedHtml || "");
       if (refsArg.commenterLabel) {
@@ -794,6 +1006,7 @@
             <div id="disconnectedBanner" class="editor-disconnected hidden">Disconnected. Reconnecting...</div>
             <textarea id="editorTextarea" class="editor-textarea" spellcheck="false"></textarea>
           </section>
+          <div class="resize-handle" id="resizeHandle"></div>
           <section class="preview-stage" id="previewStage">
             <jot-icon-button icon="close" label="Close preview" id="previewCloseButton" class="preview-close-btn"></jot-icon-button>
             <div class="preview-controls" id="previewControls">

--- a/public/app.js
+++ b/public/app.js
@@ -13,6 +13,7 @@
     (navigator.userAgent.includes("Mac") && "ontouchstart" in window && navigator.maxTouchPoints > 1);
 
   const themeIcon = window.__themeIcon || ((t) => t === "dark" ? "☀" : "☾");
+  let scrollSyncEnabled = localStorage.getItem("jot_scroll_sync") !== "off";
 
   let mermaidIdCounter = 0;
   let mermaidCache = [];
@@ -405,6 +406,15 @@
       logoutButton.addEventListener("click", logoutOwner);
     }
 
+    const scrollSyncButton = document.getElementById("scrollSyncButton");
+    if (scrollSyncButton) {
+      scrollSyncButton.addEventListener("click", () => {
+        scrollSyncEnabled = !scrollSyncEnabled;
+        localStorage.setItem("jot_scroll_sync", scrollSyncEnabled ? "on" : "off");
+        setButtonLabel(scrollSyncButton, scrollSyncEnabled ? "unsync scroll" : "sync scroll");
+      });
+    }
+
     let collabEditor = null;
 
     function initCollabEditor() {
@@ -578,6 +588,7 @@
       editorTextarea.addEventListener("scrollsync:rebuild", buildEditorLineOffsets);
 
       editorTextarea.addEventListener("scroll", () => {
+        if (!scrollSyncEnabled) return;
         if (scrollSyncSource === "preview") return;
         scrollSyncSource = "editor";
         clearSyncLock();
@@ -624,6 +635,7 @@
       });
 
       previewScroll.addEventListener("scroll", () => {
+        if (!scrollSyncEnabled) return;
         if (scrollSyncSource === "editor") return;
         scrollSyncSource = "preview";
         clearSyncLock();
@@ -978,6 +990,9 @@
         });
         setPreviewHtml(refsArg, payload.html);
         syncThreadLayout(refsArg);
+        if (refsArg.editorTextarea) {
+          refsArg.editorTextarea.dispatchEvent(new Event("scrollsync:rebuild"));
+        }
       }, 150);
     }
   }
@@ -1010,6 +1025,7 @@
           <section class="preview-stage" id="previewStage">
             <jot-icon-button icon="close" label="Close preview" id="previewCloseButton" class="preview-close-btn"></jot-icon-button>
             <div class="preview-controls" id="previewControls">
+              <jot-button variant="ghost" size="sm" id="scrollSyncButton">${scrollSyncEnabled ? "unsync scroll" : "sync scroll"}</jot-button>
               <jot-button variant="ghost" size="sm" id="commentsButton">hide comments</jot-button>
               <jot-button variant="ghost" size="sm" id="resolvedButton">resolved</jot-button>
             </div>
@@ -1091,9 +1107,11 @@
             <div id="disconnectedBanner" class="editor-disconnected hidden">Disconnected. Reconnecting...</div>
             <textarea id="editorTextarea" class="editor-textarea" spellcheck="false"></textarea>
           </section>
+          <div class="resize-handle" id="resizeHandle"></div>
           <section class="preview-stage" id="previewStage">
             <jot-icon-button icon="close" label="Close preview" id="previewCloseButton" class="preview-close-btn"></jot-icon-button>
             <div class="preview-controls" id="previewControls">
+              <jot-button variant="ghost" size="sm" id="scrollSyncButton">${scrollSyncEnabled ? "unsync scroll" : "sync scroll"}</jot-button>
               <jot-button variant="ghost" size="sm" id="commentsButton">hide comments</jot-button>
               <jot-button variant="ghost" size="sm" id="resolvedButton">resolved</jot-button>
             </div>

--- a/public/app.js
+++ b/public/app.js
@@ -503,14 +503,19 @@
       let scrollSyncSource = null;
       let scrollSyncTimer = null;
       let editorLineOffsets = null;
+      let sourceLineAnchors = null;
 
       function clearSyncLock() {
         clearTimeout(scrollSyncTimer);
         scrollSyncTimer = setTimeout(() => { scrollSyncSource = null; }, 150);
       }
 
-      function getSourceLineElements() {
-        return previewContent.querySelectorAll("[data-source-line]");
+      function buildSourceLineAnchors() {
+        const els = previewContent.querySelectorAll("[data-source-line]");
+        sourceLineAnchors = Array.from(els).map(el => ({
+          el,
+          line: parseInt(el.dataset.sourceLine, 10),
+        }));
       }
 
       function buildEditorLineOffsets() {
@@ -543,9 +548,9 @@
         }
         mirror.innerHTML = html;
 
-        for (let i = 0; i < lines.length; i++) {
-          const marker = mirror.querySelector(`[data-ln="${i}"]`);
-          offsets[i] = marker ? marker.offsetTop : 0;
+        const markers = mirror.querySelectorAll("[data-ln]");
+        for (let i = 0; i < markers.length; i++) {
+          offsets[i] = markers[i].offsetTop;
         }
 
         document.body.removeChild(mirror);
@@ -586,6 +591,7 @@
       editorTextarea.addEventListener("input", scheduleOffsetRebuild);
       new ResizeObserver(scheduleOffsetRebuild).observe(editorTextarea);
       editorTextarea.addEventListener("scrollsync:rebuild", buildEditorLineOffsets);
+      new MutationObserver(buildSourceLineAnchors).observe(previewContent, { childList: true, subtree: true });
 
       editorTextarea.addEventListener("scroll", () => {
         if (!scrollSyncEnabled) return;
@@ -593,9 +599,7 @@
         scrollSyncSource = "editor";
         clearSyncLock();
 
-        if (!editorLineOffsets) return;
-        const elements = getSourceLineElements();
-        if (!elements.length) return;
+        if (!editorLineOffsets || !sourceLineAnchors || !sourceLineAnchors.length) return;
 
         if (editorTextarea.scrollTop + editorTextarea.clientHeight >= editorTextarea.scrollHeight - 2) {
           previewScroll.scrollTop = previewScroll.scrollHeight;
@@ -606,12 +610,11 @@
 
         let prev = null;
         let next = null;
-        for (const el of elements) {
-          const sl = parseInt(el.dataset.sourceLine, 10);
-          if (sl <= topLine) {
-            prev = el;
+        for (const a of sourceLineAnchors) {
+          if (a.line <= topLine) {
+            prev = a;
           } else {
-            next = el;
+            next = a;
             break;
           }
         }
@@ -621,13 +624,11 @@
           return;
         }
 
-        const prevLine = parseInt(prev.dataset.sourceLine, 10);
-        let targetTop = prev.offsetTop - previewContent.offsetTop;
+        let targetTop = prev.el.offsetTop - previewContent.offsetTop;
 
         if (next) {
-          const nextLine = parseInt(next.dataset.sourceLine, 10);
-          const nextTop = next.offsetTop - previewContent.offsetTop;
-          const frac = nextLine > prevLine ? (topLine - prevLine) / (nextLine - prevLine) : 0;
+          const nextTop = next.el.offsetTop - previewContent.offsetTop;
+          const frac = next.line > prev.line ? (topLine - prev.line) / (next.line - prev.line) : 0;
           targetTop += (nextTop - targetTop) * frac;
         }
 
@@ -640,9 +641,7 @@
         scrollSyncSource = "preview";
         clearSyncLock();
 
-        if (!editorLineOffsets) return;
-        const elements = getSourceLineElements();
-        if (!elements.length) return;
+        if (!editorLineOffsets || !sourceLineAnchors || !sourceLineAnchors.length) return;
 
         if (previewScroll.scrollTop + previewScroll.clientHeight >= previewScroll.scrollHeight - 2) {
           editorTextarea.scrollTop = editorTextarea.scrollHeight;
@@ -652,12 +651,12 @@
         const scrollY = previewScroll.scrollTop;
         let prev = null;
         let next = null;
-        for (const el of elements) {
-          const elTop = el.offsetTop - previewContent.offsetTop;
+        for (const a of sourceLineAnchors) {
+          const elTop = a.el.offsetTop - previewContent.offsetTop;
           if (elTop <= scrollY) {
-            prev = el;
+            prev = a;
           } else {
-            next = el;
+            next = a;
             break;
           }
         }
@@ -667,16 +666,14 @@
           return;
         }
 
-        const prevLine = parseInt(prev.dataset.sourceLine, 10);
-        let targetLine = prevLine;
+        let targetLine = prev.line;
 
         if (next) {
-          const prevTop = prev.offsetTop - previewContent.offsetTop;
-          const nextTop = next.offsetTop - previewContent.offsetTop;
-          const nextLine = parseInt(next.dataset.sourceLine, 10);
+          const prevTop = prev.el.offsetTop - previewContent.offsetTop;
+          const nextTop = next.el.offsetTop - previewContent.offsetTop;
           const span = nextTop - prevTop;
           const frac = span > 0 ? (scrollY - prevTop) / span : 0;
-          targetLine += (nextLine - prevLine) * frac;
+          targetLine += (next.line - prev.line) * frac;
         }
 
         editorTextarea.scrollTop = sourceLineToEditorPixel(targetLine);
@@ -688,27 +685,31 @@
     if (resizeHandle) {
       let dragging = false;
       const workspace = document.querySelector(".workspace");
-      resizeHandle.addEventListener("mousedown", (e) => {
-        e.preventDefault();
-        dragging = true;
-        resizeHandle.classList.add("dragging");
-        document.body.style.cursor = "col-resize";
-        document.body.style.userSelect = "none";
-      });
-      document.addEventListener("mousemove", (e) => {
-        if (!dragging || !workspace) return;
-        const rect = workspace.getBoundingClientRect();
-        const pct = ((e.clientX - rect.left) / rect.width) * 100;
-        const clamped = Math.max(20, Math.min(80, pct));
-        workspace.style.gridTemplateColumns = `${clamped}% 4px 1fr`;
-      });
-      document.addEventListener("mouseup", () => {
+      function stopDrag() {
         if (!dragging) return;
         dragging = false;
         resizeHandle.classList.remove("dragging");
         document.body.style.cursor = "";
         document.body.style.userSelect = "";
+      }
+      resizeHandle.addEventListener("pointerdown", (e) => {
+        e.preventDefault();
+        resizeHandle.setPointerCapture(e.pointerId);
+        dragging = true;
+        resizeHandle.classList.add("dragging");
+        document.body.style.cursor = "col-resize";
+        document.body.style.userSelect = "none";
       });
+      document.addEventListener("pointermove", (e) => {
+        if (!dragging || !workspace) return;
+        const rect = workspace.getBoundingClientRect();
+        const pct = ((e.clientX - rect.left) / rect.width) * 100;
+        const clamped = Math.max(20, Math.min(80, pct));
+        workspace.style.gridTemplateColumns = `${clamped}fr 4px ${100 - clamped}fr`;
+      });
+      document.addEventListener("pointerup", stopDrag);
+      document.addEventListener("pointercancel", stopDrag);
+      resizeHandle.addEventListener("lostpointercapture", stopDrag);
     }
 
     document.addEventListener("selectionchange", () => {

--- a/public/styles.css
+++ b/public/styles.css
@@ -257,13 +257,18 @@ input:focus, textarea:focus { border-color: var(--muted); }
 .icon-action.copy-success { color: var(--green); }
 
 .workspace {
-  display: grid; grid-template-columns: 1fr 1fr;
+  display: grid; grid-template-columns: 1fr 4px 1fr;
   height: calc(100vh - var(--toolbar-height)); overflow: hidden;
 }
 .editor-pane {
-  border-right: 1px solid var(--line); background: var(--editor-bg); overflow: hidden;
+  background: var(--editor-bg); overflow: hidden;
   display: flex; flex-direction: column; position: relative;
 }
+.resize-handle {
+  width: 4px; cursor: col-resize; background: var(--line); position: relative; z-index: 20;
+  transition: background 0.15s;
+}
+.resize-handle:hover, .resize-handle.dragging { background: var(--blue, #58a6ff); }
 
 .editor-textarea {
   width: 100%; flex: 1; min-height: 0;
@@ -494,6 +499,7 @@ input:focus, textarea:focus { border-color: var(--muted); }
 /* --- Narrow / mobile --- */
 @media (max-width: 980px) {
   .workspace { grid-template-columns: 1fr; }
+  .resize-handle { display: none; }
   .editor-pane { border-right: 0; border-bottom: none; }
 
   /* Hide preview by default in editor, show when toggled */

--- a/public/styles.css
+++ b/public/styles.css
@@ -498,7 +498,7 @@ input:focus, textarea:focus { border-color: var(--muted); }
 
 /* --- Narrow / mobile --- */
 @media (max-width: 980px) {
-  .workspace { grid-template-columns: 1fr; }
+  .workspace { grid-template-columns: 1fr !important; }
   .resize-handle { display: none; }
   .editor-pane { border-right: 0; border-bottom: none; }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -139,18 +139,58 @@ const ownerCookieMaxAgeSeconds = 60 * 60 * 24 * 30;
 const commenterCookieMaxAgeSeconds = 60 * 60 * 24 * 365;
 const notes = new Map<string, NoteRecord>();
 
+function slAttr(token: any) {
+  return token.sourceLine != null ? ` data-source-line="${token.sourceLine}"` : "";
+}
+
 const codeRenderer = new marked.Renderer();
-codeRenderer.code = ({ text, lang }: Tokens.Code) => {
-  const language = (lang || "").trim().split(/\s+/)[0];
+codeRenderer.code = function (token: Tokens.Code) {
+  const language = (token.lang || "").trim().split(/\s+/)[0];
   if (language === "mermaid") {
-    return `<pre class="mermaid">${escapeHtml(text)}</pre>`;
+    return `<pre class="mermaid"${slAttr(token)}>${escapeHtml(token.text)}</pre>`;
   }
   const validLanguage = language && hljs.getLanguage(language) ? language : null;
   const highlighted = validLanguage
-    ? hljs.highlight(text, { language: validLanguage }).value
-    : escapeHtml(text);
+    ? hljs.highlight(token.text, { language: validLanguage }).value
+    : escapeHtml(token.text);
   const languageClass = validLanguage ? ` class="hljs language-${escapeHtml(validLanguage)}"` : ' class="hljs"';
-  return `<pre><code${languageClass}>${highlighted}</code></pre>`;
+  return `<pre${slAttr(token)}><code${languageClass}>${highlighted}</code></pre>`;
+};
+codeRenderer.heading = function (token: Tokens.Heading) {
+  return `<h${token.depth}${slAttr(token)}>${this.parser.parseInline(token.tokens)}</h${token.depth}>\n`;
+};
+codeRenderer.paragraph = function (token: Tokens.Paragraph) {
+  return `<p${slAttr(token)}>${this.parser.parseInline(token.tokens)}</p>\n`;
+};
+codeRenderer.blockquote = function (token: Tokens.Blockquote) {
+  return `<blockquote${slAttr(token)}>\n${this.parser.parse(token.tokens)}</blockquote>\n`;
+};
+codeRenderer.list = function (token: Tokens.List) {
+  const tag = token.ordered ? "ol" : "ul";
+  let body = "";
+  for (const item of token.items) {
+    body += this.listitem(item);
+  }
+  return `<${tag}${slAttr(token)}>\n${body}</${tag}>\n`;
+};
+codeRenderer.table = function (token: Tokens.Table) {
+  let header = "";
+  for (const cell of token.header) {
+    header += this.tablecell(cell);
+  }
+  header = this.tablerow({ text: header } as Tokens.TableRow);
+  let body = "";
+  for (const row of token.rows) {
+    let rowContent = "";
+    for (const cell of row) {
+      rowContent += this.tablecell(cell);
+    }
+    body += this.tablerow({ text: rowContent } as Tokens.TableRow);
+  }
+  return `<table${slAttr(token)}>\n<thead>\n${header}</thead>\n<tbody>\n${body}</tbody>\n</table>\n`;
+};
+codeRenderer.hr = function (token: Tokens.Hr) {
+  return `<hr${slAttr(token)}>\n`;
 };
 
 marked.setOptions({
@@ -1698,7 +1738,13 @@ function sanitizeAnchor(input: unknown) {
 }
 
 function renderMarkdown(markdown: string) {
-  const rawHtml = marked.parse(markdown) as string;
+  const tokens = marked.lexer(markdown);
+  let line = 0;
+  for (const token of tokens) {
+    (token as any).sourceLine = line;
+    line += (token.raw.match(/\n/g) || []).length;
+  }
+  const rawHtml = marked.parser(tokens);
   return sanitizeHtml(rawHtml, {
     allowedTags: sanitizeHtml.defaults.allowedTags.concat([
       "img",
@@ -1724,6 +1770,19 @@ function renderMarkdown(markdown: string) {
       img: ["src", "alt", "title"],
       code: ["class"],
       span: ["class"],
+      h1: ["data-source-line"],
+      h2: ["data-source-line"],
+      h3: ["data-source-line"],
+      h4: ["data-source-line"],
+      h5: ["data-source-line"],
+      h6: ["data-source-line"],
+      p: ["data-source-line"],
+      pre: ["data-source-line"],
+      blockquote: ["data-source-line"],
+      ul: ["data-source-line"],
+      ol: ["data-source-line"],
+      table: ["data-source-line"],
+      hr: ["data-source-line"],
     },
     allowedClasses: {
       code: ["hljs", /^language-/],

--- a/src/server.ts
+++ b/src/server.ts
@@ -173,6 +173,10 @@ codeRenderer.list = function (token: Tokens.List) {
   }
   return `<${tag}${slAttr(token)}>\n${body}</${tag}>\n`;
 };
+codeRenderer.listitem = function (token: Tokens.ListItem) {
+  const html = marked.Renderer.prototype.listitem.call(this, token);
+  return html.replace("<li>", `<li${slAttr(token)}>`);
+};
 codeRenderer.table = function (token: Tokens.Table) {
   let header = "";
   for (const cell of token.header) {
@@ -1737,13 +1741,22 @@ function sanitizeAnchor(input: unknown) {
   return { quote, prefix, suffix, start, end } satisfies CommentAnchor;
 }
 
-function renderMarkdown(markdown: string) {
-  const tokens = marked.lexer(markdown);
-  let line = 0;
+function annotateSourceLines(tokens: any[], startLine: number) {
+  let line = startLine;
   for (const token of tokens) {
-    (token as any).sourceLine = line;
+    token.sourceLine = line;
+    if (token.type === "list" && token.items) {
+      annotateSourceLines(token.items, line);
+    } else if ((token.type === "blockquote" || token.type === "list_item") && token.tokens) {
+      annotateSourceLines(token.tokens, line);
+    }
     line += (token.raw.match(/\n/g) || []).length;
   }
+}
+
+function renderMarkdown(markdown: string) {
+  const tokens = marked.lexer(markdown);
+  annotateSourceLines(tokens, 0);
   const rawHtml = marked.parser(tokens);
   return sanitizeHtml(rawHtml, {
     allowedTags: sanitizeHtml.defaults.allowedTags.concat([
@@ -1781,6 +1794,7 @@ function renderMarkdown(markdown: string) {
       blockquote: ["data-source-line"],
       ul: ["data-source-line"],
       ol: ["data-source-line"],
+      li: ["data-source-line"],
       table: ["data-source-line"],
       hr: ["data-source-line"],
     },


### PR DESCRIPTION
## Summary

- **Source-map scroll sync**: Injects `data-source-line` attributes on block-level HTML elements (headings, paragraphs, code blocks, lists, blockquotes, tables, hrs) during `marked` rendering. Uses a hidden mirror div to measure word-wrap-aware pixel offsets in the textarea, enabling accurate bidirectional scroll synchronization between the raw markdown editor and the rendered preview.
- **Scroll sync toggle**: Adds "sync scroll" / "unsync scroll" button in preview controls, persisted in localStorage. Can be toggled at any time without reloading.
- **Resizable split pane**: Adds a draggable 4px separator between editor and preview panes, allowing users to adjust the split ratio (clamped 20-80%). Hidden on mobile where the preview is a full-screen overlay.

## How scroll sync works

1. `marked.lexer()` tokenizes the markdown, each top-level token is annotated with its source line number
2. Custom renderers inject `data-source-line="N"` on the rendered HTML elements
3. On editor scroll: a mirror div (matching textarea styling) measures where each source line sits in pixels, accounting for word wrap. Binary search finds which source line is at the current scroll position, then the preview scrolls to the matching `[data-source-line]` element with interpolation.
4. On preview scroll: finds the first visible `[data-source-line]` element, maps back to the source line, scrolls the editor to the corresponding pixel offset.
5. A 150ms sync lock prevents feedback loops between the two directions.

## Changes

- `src/server.ts`: Extended `marked.Renderer` for all block elements with `data-source-line`, changed `renderMarkdown` to use lexer+annotate+parser pipeline, updated sanitize-html allowedAttributes
- `public/app.js`: Added ~200 lines for scroll sync + resize handle + toggle logic. Added resize handle to both owner and public editor layouts. Fixed scroll sync initialization for collab editor path.
- `public/styles.css`: Changed workspace grid to `1fr 4px 1fr`, added resize handle styles, mobile breakpoint hides handle

## Test plan

- [x] Open a note with enough content to scroll both panes
- [x] Scroll the editor — preview should follow with matching section alignment
- [x] Scroll the preview — editor should follow back
- [x] Scroll either pane to the bottom — the other should also reach bottom
- [x] Click "unsync scroll" — scrolling either pane no longer syncs the other
- [x] Click "sync scroll" — sync resumes; preference persists across reload
- [x] Drag the resize handle left/right — panes should resize (clamped 20-80%)
- [x] On mobile viewport: resize handle hidden, grid resets to single column
- [x] Edit content — scroll sync should recalibrate after typing
- [x] Open a shared edit link — resize handle and sync toggle both present