### PR TITLE
Allow width and height on images

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1721,7 +1721,7 @@ function renderMarkdown(markdown: string) {
     ]),
     allowedAttributes: {
       a: ["href", "name", "target", "rel"],
-      img: ["src", "alt", "title"],
+      img: ["src", "alt", "title", "width", "height"],
       code: ["class"],
       span: ["class"],
     },


### PR DESCRIPTION
I needed a way to resize some huge PNG; I guess I won't be the only one and adding width and height to allowed attributes seems a low-risk approach. 