### PR TITLE
fix(editor): allow typing on non-secure-context origins

### DIFF
--- a/public/collab-editor.js
+++ b/public/collab-editor.js
@@ -11,6 +11,17 @@ const RECONNECT_BASE_MS = 1000;
 const RECONNECT_MAX_MS = 15000;
 const PRESENCE_STALE_MS = 60000;
 
+// crypto.randomUUID is only available in secure contexts (HTTPS, localhost, file://).
+// Fall back to crypto.getRandomValues so plain-HTTP origins (e.g. Docker on a LAN IP) still work.
+const randomUUID = () => {
+  if (crypto.randomUUID) return crypto.randomUUID();
+  const b = crypto.getRandomValues(new Uint8Array(16));
+  b[6] = (b[6] & 0x0f) | 0x40; // version 4
+  b[8] = (b[8] & 0x3f) | 0x80; // RFC 4122 variant
+  const h = Array.from(b, (x) => x.toString(16).padStart(2, "0")).join("");
+  return `${h.slice(0,8)}-${h.slice(8,12)}-${h.slice(12,16)}-${h.slice(16,20)}-${h.slice(20)}`;
+};
+
 function isWordChar(ch) { return /[0-9A-Za-z_]/.test(ch || ""); }
 
 function readInsertText(event) {
@@ -160,7 +171,7 @@ export function createCollabEditor(textarea, opts) {
       }
     }
     return {
-      bunchId: `${clientId}:${nextBunchIdCounter++}:${crypto.randomUUID()}`,
+      bunchId: `${clientId}:${nextBunchIdCounter++}:${randomUUID()}`,
       counter: 0,
     };
   }


### PR DESCRIPTION
Fixes #5.

## Problem

`crypto.randomUUID()` at `public/collab-editor.js:163` is only defined in [secure contexts](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID) (HTTPS, `localhost`, `127.0.0.1`, `file://`). On plain HTTP from a non-loopback origin — Docker on a LAN IP, global install accessed remotely — it's `undefined`, and the editor throws on every keystroke. Title editing works because it doesn't go through the CRDT mutation path.

Full reproduction, table comparison, and stack-trace match in #5 (comment).

## Fix

Tiny `randomUUID()` shim near the top of `public/collab-editor.js` that prefers `crypto.randomUUID` when present and falls back to `crypto.getRandomValues`-based RFC 4122 v4 generation, which is *not* gated to secure contexts. Same 122 bits of entropy.

One call site updated (line 163). Server-side calls in `src/collab.ts` and `src/server.ts` are untouched — Node's `crypto.randomUUID` has no secure-context restriction.

## Verification

Playwright run against the same `jot serve --port=3210` instance from two origins, before and after the fix:

|  | localhost (before) | LAN IP (before) | localhost (after) | LAN IP (after) |
|--|--|--|--|--|
| `isSecureContext` | `true` | `false` | `true` | `false` |
| `typeof crypto.randomUUID` | `"function"` | `"undefined"` | `"function"` | `"undefined"` |
| Body typing — pageErrors | `0` | `10` | `0` | `0` |
| Body textarea value | `"hello body"` | `""` | `"hello body"` | `"hello body"` |

So: localhost behavior unchanged, LAN IP now works.

## Notes

- The shim is plain JS, no dep added.
- Diff is +12 / −1, all in `public/collab-editor.js`.
- Branch is rebased on current `main` (`6242f11`), no merge commits.
